### PR TITLE
feat: Add solvent density to convert from molality to molarity in GEOS

### DIFF
--- a/src/common/constants.hpp
+++ b/src/common/constants.hpp
@@ -19,6 +19,7 @@ namespace constants
 constexpr double R = 8.31446261815324; // J/(mol K)
 constexpr double F = 96485.3321233100184; // C/mol
 constexpr double NA = 6.02214076e23; // 1/mol
+constexpr double waterDensity = 1000.0; // kg/m3
 
 } // namespace constants
 } // namespace hpcReact

--- a/src/reactions/exampleSystems/BulkGeneric.hpp
+++ b/src/reactions/exampleSystems/BulkGeneric.hpp
@@ -65,7 +65,9 @@ simpleKineticTestRateParams =
   // flag of mobile secondary species
   { 1, 1 },
   // Use the forward and reverse to calculate the kinetic reaction rates
-  0
+  0,
+  // Solvent density
+  1.0
 };
 
 using simpleTestType = reactionsSystems::MixedReactionsParameters< double, int, signed char, 5, 2, 2 >;
@@ -88,7 +90,9 @@ simpleTestRateParams =
   // flag of mobile secondary species
   { 1, 1 },
   // Use the forward and reverse to calculate the kinetic reaction rates
-  0
+  0,
+  // Solvent density
+  1.0
 };
 
 // *****UNCRUSTIFY-ON******

--- a/src/reactions/exampleSystems/ChainGeneric.hpp
+++ b/src/reactions/exampleSystems/ChainGeneric.hpp
@@ -60,7 +60,8 @@ namespace ChainGeneric
       1  // C3
     },
 
-    0 // Use the forward and reverse to calculate the kinetic reaction rates
+    0, // Use the forward and reverse to calculate the kinetic reaction rates
+    1.0  // Solvent density
   };
 
 // *****UNCRUSTIFY-ON******

--- a/src/reactions/exampleSystems/MoMasBenchmark.hpp
+++ b/src/reactions/exampleSystems/MoMasBenchmark.hpp
@@ -79,7 +79,13 @@ namespace MoMasBenchmark
     1, // C5 = 4X2 + 3X3 + X4
     0, // CS1 = 3X2 + X3 + S
     0  // CS2 = -3X2 + X4 + 2S
-  }
+  },
+
+  // Reaction rates update option
+  1,
+
+  // Solvent density
+  1.0
 };
 
 constexpr mediumCaseType mediumCaseParams =
@@ -154,7 +160,13 @@ constexpr mediumCaseType mediumCaseParams =
     0, // CS1 = 3X2 + X3 + S
     0, // CS2 = -3X2 + X4 + 2S
     1  // Cc = -3X2 + X4 (kinetic)
-  }
+  },
+
+  // Reaction rates update option
+  1,
+
+  // Solvent density
+  1.0
 };
 
 // *****UNCRUSTIFY-ON******

--- a/src/reactions/reactionsSystems/Parameters.hpp
+++ b/src/reactions/reactionsSystems/Parameters.hpp
@@ -136,13 +136,15 @@ struct MixedReactionsParameters
                                       CArrayWrapper< RealType, NUM_REACTIONS > const & rateConstantForward,
                                       CArrayWrapper< RealType, NUM_REACTIONS > const & rateConstantReverse,
                                       CArrayWrapper< IntType, NUM_REACTIONS > mobileSecondarySpeciesFlag,
-                                      IntType const reactionRatesUpdateOption = 1 ):
+                                      IntType const reactionRatesUpdateOption = 1,
+                                      RealType const solventDensity = constants::waterDensity ):
     m_stoichiometricMatrix( stoichiometricMatrix ),
     m_equilibriumConstant( equilibriumConstant ),
     m_rateConstantForward( rateConstantForward ),
     m_rateConstantReverse( rateConstantReverse ),
     m_mobileSecondarySpeciesFlag( mobileSecondarySpeciesFlag ),
-    m_reactionRatesUpdateOption( reactionRatesUpdateOption )
+    m_reactionRatesUpdateOption( reactionRatesUpdateOption ),
+    m_solventDensity( solventDensity )
   {}
 
   HPCREACT_HOST_DEVICE static constexpr IndexType numReactions() { return NUM_REACTIONS; }
@@ -239,6 +241,8 @@ struct MixedReactionsParameters
     }
   }
 
+  HPCREACT_HOST_DEVICE constexpr RealType getSolventDensity() const { return m_solventDensity; }
+
   HPCREACT_HOST_DEVICE IndexType stoichiometricMatrix( IndexType const r, int const i ) const { return m_stoichiometricMatrix[r][i]; }
   HPCREACT_HOST_DEVICE RealType equilibriumConstant( IndexType const r ) const { return m_equilibriumConstant[r]; }
   HPCREACT_HOST_DEVICE RealType rateConstantForward( IndexType const r ) const { return m_rateConstantForward[r]; }
@@ -251,6 +255,7 @@ struct MixedReactionsParameters
   CArrayWrapper< IntType, NUM_REACTIONS > m_mobileSecondarySpeciesFlag;
 
   IntType m_reactionRatesUpdateOption; // 0: forward and reverse rate. 1: quotient form.
+  RealType m_solventDensity; // Unit should be kg/m3
 };
 
 


### PR DESCRIPTION
This PR adds the `solventDensity` in Parameters, so that we can get it in GEOS to convert from molality concentration to molarity concentration. 

Now, the concentration in HPCReact should be considered as molality to be compatible with the activity model and EQ36 database. 