### PR TITLE
Update submodule URL to relative path

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake/blt"]
 	path = cmake/blt
-	url = git@github.com:LLNL/blt.git
+	url = https://github.com/LLNL/blt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cmake/blt"]
 	path = cmake/blt
-	url = https://github.com/LLNL/blt.git
+	url = ../../LLNL/blt.git


### PR DESCRIPTION
Github runner needs https so it doesn't bother with ssh keys